### PR TITLE
Placeholder mixin, horizontal margin classes, typo fix

### DIFF
--- a/src/_mixins/_mixins.scss
+++ b/src/_mixins/_mixins.scss
@@ -6,3 +6,4 @@
 @import "hover"
 @import "shadows";
 @import "transitions";
+@import "placeholder";

--- a/src/_mixins/_placeholder.scss
+++ b/src/_mixins/_placeholder.scss
@@ -1,0 +1,22 @@
+// ----------------------------------------------------------------------------
+// Placeholder mixin
+// ----------------------------------------------------------------------------
+
+/// Provides support for cross-browser form input placeholder styles
+///
+/// @access public
+/// @content Any declarations to style placeholders
+/// @example
+///   .foo {
+///     @include placeholder {
+///       color: $gray-light;
+///       opacity: 1;
+///     };
+///   }
+
+@mixin placeholder {
+  &::-webkit-input-placeholder {@content}
+  &:-moz-placeholder           {@content}
+  &::-moz-placeholder          {@content}
+  &:-ms-input-placeholder      {@content}
+}

--- a/src/_mixins/_spacing.scss
+++ b/src/_mixins/_spacing.scss
@@ -20,7 +20,6 @@
 /// m = medium
 /// n = none
 /// s = small
-/// a = auto
 ///
 /// @require {function} rem
 /// @param {map} $map - Single key/value pair indicating property and abbr.

--- a/src/base/_form-content.scss
+++ b/src/base/_form-content.scss
@@ -9,6 +9,7 @@
 // Dependences
 @import "../config";
 @import "../_mixins/borders";
+@import '../_mixins/placeholder';
 
 /**
  * 1. Change font properties to `inherit` in all browsers (opinionated).
@@ -192,7 +193,7 @@ textarea {
  * Correct the text style of placeholders in Chrome, Edge, and Safari.
  */
 
-::-webkit-input-placeholder {
+@include placeholder {
   opacity: 0.54;
 
   color: $color-grey-500;

--- a/src/components/Editor/_editor.scss
+++ b/src/components/Editor/_editor.scss
@@ -8,6 +8,7 @@
 @import '../../config';
 @import "../../_mixins/borders";
 @import "../../_mixins/transitions";
+@import "../../_mixins/placeholder";
 @import "../../_functions/rem";
 
 // Main container component
@@ -89,7 +90,7 @@
 
   will-change: transform;
 
-  &::placeholder {
+  @include placeholder {
     opacity: 0.54;
 
     font-weight: 200;

--- a/src/helpers/_image.scss
+++ b/src/helpers/_image.scss
@@ -4,7 +4,7 @@
 // 1. Let height adjust to width and prevent stretching.
 // 2. Set maximum width relative to its containing box.
 
-.imgage-fluid {
+.image-fluid {
   height: auto !important; // 1
   max-width: 100% !important; // 2
 }

--- a/src/helpers/_margin.scss
+++ b/src/helpers/_margin.scss
@@ -28,3 +28,6 @@
 // NOTE: To reduce verbosity of selector name, abbreviated 'margin' to 'm'.
 
 @include spacing((margin: 'm'), $spacings);
+
+.mla, .mha { margin-left: auto; }
+.mra, .mha { margin-right: auto; }

--- a/src/helpers/_padding.scss
+++ b/src/helpers/_padding.scss
@@ -17,7 +17,6 @@
 // m = medium
 // n = none
 // s = small
-// a = auto
 
 // Dependencies
 


### PR DESCRIPTION
1. Added placeholder mixin to support cross-browser input placeholders
2. Fixed typo in image helper
3. Added horizontal margin classes. Doesn't make sense to add `auto` to `$spacings` because vertical margins can't be set to auto nor can any padding properties.